### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ A Nuxt module for adding animate on scroll to your application.
 1. Add `nuxt-aos` dependency to your project
 
 ```bash
-# Using pnpm
-npx nuxi@latest module add aos
-
-# Using yarn
-npx nuxi@latest module add aos
-
-# Using npm
 npx nuxi@latest module add aos
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ A Nuxt module for adding animate on scroll to your application.
 
 ```bash
 # Using pnpm
-pnpm add -D nuxt-aos
+npx nuxi@latest module add aos
 
 # Using yarn
-yarn add --dev nuxt-aos
+npx nuxi@latest module add aos
 
 # Using npm
-npm install --save-dev nuxt-aos
+npx nuxi@latest module add aos
 ```
 
 2. Add `nuxt-aos` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
