### PR TITLE
improve AOS config merging and add default duration

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -4,7 +4,7 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 import 'aos/dist/aos.css'
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.hook('app:suspense:resolve', () => {
+  nuxtApp.hook('app:mounted', () => {
     const config = useRuntimeConfig()
     AOS.init(config.public.aos || {})
   })

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import AOS from 'aos'
+import AOS, { type AosOptions } from 'aos'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 
 import 'aos/dist/aos.css'
@@ -6,7 +6,17 @@ import 'aos/dist/aos.css'
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hook('app:mounted', () => {
     const config = useRuntimeConfig()
-    AOS.init(config.public.aos || {})
+    const aosConfig: AosOptions = {
+      ...config.public.aos,
+      duration: config.public.aos?.duration || 600,
+      delay: config.public.aos?.delay || 0,
+      offset: config.public.aos?.offset || 120,
+      easing: config.public.aos?.easing || "ease",
+      once: config.public.aos?.once || false, 
+      mirror: config.public.aos?.mirror || false
+    }
+
+    AOS.init(aosConfig)
   })
 
   const refreshAos = () => AOS.refresh()

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -4,7 +4,7 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 import 'aos/dist/aos.css'
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.hook('app:mounted', () => {
+  nuxtApp.hook('app:suspense:resolve', () => {
     const config = useRuntimeConfig()
     const aosConfig: AosOptions = {
       ...config.public.aos,


### PR DESCRIPTION
### Summary
- Fixed the merging of AOS configuration values from `nuxt.config.ts` and added default values for `duration`.
- Improved AOS initialization to handle missing configuration values gracefully.

### Changes
- Merged the `aosConfig` values from `config.public.aos` and provided default values like `duration: 600`.
- Used TypeScript's `AOSOptions` type to ensure correct configuration structure.
- Updated the AOS initialization to correctly handle merged configuration.

### Why
This fix ensures that the AOS configuration behaves as expected, even when certain values are missing from the config file, and provides reasonable defaults to improve the development experience.
